### PR TITLE
Use GitHub GraphQL API instead of REST

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 gem 'celluloid-io'
-gem 'github_api'
+gem 'graphql-client'
 gem 'sinatra'
 gem 'web'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,11 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    activesupport (5.2.0)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
     celluloid (0.17.3)
       celluloid-essentials
       celluloid-extras
@@ -24,33 +27,19 @@ GEM
       timers (>= 4.1.1)
     celluloid-supervision (0.20.6)
       timers (>= 4.1.1)
-    descendants_tracker (0.0.4)
-      thread_safe (~> 0.3, >= 0.3.1)
-    faraday (0.12.2)
-      multipart-post (>= 1.2, < 3)
+    concurrent-ruby (1.0.5)
     foreman (0.84.0)
       thor (~> 0.19.1)
-    github_api (0.18.2)
-      addressable (~> 2.4)
-      descendants_tracker (~> 0.0.4)
-      faraday (~> 0.8)
-      hashie (~> 3.5, >= 3.5.2)
-      oauth2 (~> 1.0)
-    hashie (3.5.7)
+    graphql (1.8.1)
+    graphql-client (0.12.3)
+      activesupport (>= 3.0, < 6.0)
+      graphql (~> 1.6)
     hitimes (1.2.4)
-    jwt (1.5.6)
-    multi_json (1.13.1)
-    multi_xml (0.6.0)
-    multipart-post (2.0.0)
+    i18n (1.0.1)
+      concurrent-ruby (~> 1.0)
+    minitest (5.11.3)
     mustermann (1.0.2)
     nio4r (2.0.0)
-    oauth2 (1.4.0)
-      faraday (>= 0.8, < 0.13)
-      jwt (~> 1.0)
-      multi_json (~> 1.3)
-      multi_xml (~> 0.5)
-      rack (>= 1.2, < 3)
-    public_suffix (3.0.2)
     rack (2.0.4)
     rack-protection (2.0.1)
       rack
@@ -64,6 +53,8 @@ GEM
     tilt (2.0.8)
     timers (4.1.2)
       hitimes
+    tzinfo (1.2.5)
+      thread_safe (~> 0.1)
     web (0.1.0)
 
 PLATFORMS
@@ -72,9 +63,9 @@ PLATFORMS
 DEPENDENCIES
   celluloid-io
   foreman
-  github_api
+  graphql-client
   sinatra
   web
 
 BUNDLED WITH
-   1.12.5
+   1.16.1


### PR DESCRIPTION
[GitHub's GraphQL API](https://developer.github.com/v4/) is significantly faster for the sort of heavily linked queries we're doing because they handle it all in one request.

This completely changes the method by which we request the data to use the GraphQL API.

For the moment, I've also removed the ability to list who issues are assigned to, because that involves walking further down the graph, which just complicates matters more than we really need.