### PR TITLE
Show pull requests' age in output

### DIFF
--- a/web.rb
+++ b/web.rb
@@ -124,10 +124,18 @@ class WebListener < Sinatra::Base
   def read_prs_for_message(organization, text)
     if text =~ /for team ([^.]+)\.?/
       team = Regexp.last_match[1]
-      read_team_prs(organization, team)
+      begin
+        read_team_prs(organization, team)
+      rescue => e
+        body(%({"text": "Couldn't read PRs for team `#{team}` in `#{organization}` organization"}))
+      end
     elsif text =~ /in repo ([^.]+)\.?/
       repo = Regexp.last_match[1]
-      read_prs_for_repo(organization, repo)
+      begin
+        read_prs_for_repo(organization, repo)
+      rescue => e
+        body(%({"text": "Couldn't read PRs for repo `#{repo}` in `#{organization}` organization"}))
+      end
     elsif
       usage
     end

--- a/web.rb
+++ b/web.rb
@@ -26,8 +26,8 @@ class WebListener < Sinatra::Base
           nodes {
             number
             url
-            id
             title
+            createdAt
             author {
               login
             }
@@ -47,8 +47,8 @@ class WebListener < Sinatra::Base
                 nodes {
                   number
                   url
-                  id
                   title
+                  createdAt
                   author {
                     login
                   }
@@ -75,7 +75,8 @@ class WebListener < Sinatra::Base
           number: pr.number,
           title: pr.title,
           url: pr.url,
-          author: pr.author.login
+          author: pr.author.login,
+          created_at: Date.parse(pr.created_at)
         }
       }
     }.flatten
@@ -94,7 +95,8 @@ class WebListener < Sinatra::Base
   end
 
   def format_pr(pr)
-    "• <#{pr[:url]}|#{pr_title(pr)}> by #{pr[:author]}"
+    pr_age = (Date.today - pr[:created_at]).to_i
+    "• <#{pr[:url]}|#{pr_title(pr)}> by #{pr[:author]} (#{pr_age}d old)"
   end
 
   get '/' do

--- a/web.rb
+++ b/web.rb
@@ -61,7 +61,6 @@ class WebListener < Sinatra::Base
     }
   GRAPHQL
 
-  DEFAULT_REPOS = %w[bootstrap-cfn bootstrap-salt template-deploy].freeze
 
   def read_team_prs(team)
     result = GithubClient.query(TeamPRQuery, variables: {
@@ -83,15 +82,8 @@ class WebListener < Sinatra::Base
     }.flatten
   end
 
-  def read_default_repos
-    DEFAULT_REPOS.map do |repo|
-      read_prs_for_repo repo
-    end.flatten
-  end
-
   def usage
     usages = [
-      'open prs',
       'open prs for team &lt;team&gt;',
       'open prs in repo &lt;repo&gt;'
     ].map { |s| "`#{s}`" }
@@ -135,10 +127,8 @@ class WebListener < Sinatra::Base
       read_team_prs(Regexp.last_match[1]) || body('{"text": "No such team"}')
     elsif text =~ /in repo ([^.]+)\.?/
       read_prs_for_repo Regexp.last_match[1]
-    elsif text =~ /help/ || text =~ /open prs /
+    elsif
       usage
-    else
-      read_default_repos
     end
   end
 


### PR DESCRIPTION
It's often useful to get context on how old the pull requests are, so we can know what's no longer relevant (and in need of closing) or has been open longer than we'd like (and needs attention).

This is a bit hacky in terms of the maths, but I think it's right.

This PR also adds some simple error handling, removes the last vestiges of the hard-coded organization name, and removes the unnecessary default repositories.