### PR TITLE
Add a deprecation notice, suggesting Pull Panda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 PR Bot
 ======
 
+DEPRECATION NOTICE
+------------------
+
+Using this slack bot to list your open PRs is not recommended, because in the past it has exhausted the free tier on Heroku, so it sometimes doesn't work.
+
+In the time since this bot was created, [GitHub] have acquired [Pull Panda], which offers a superset of this functionality. Pull panda is free to use, so that is now the recommended approach.
+
+Pull Panda is available via the [GitHub Marketplace].
+
+[GitHub]: https://github.com
+[Pull Panda]: https://pullpanda.com
+[GitHub Marketplace]: https://github.com/marketplace/pull-panda
+
 Introduction
 ------------
 


### PR DESCRIPTION
This bot exhausted the Heroku free usage tier, this month.
Rather than pay to host it, which is another thing we have to
manage on an ongoing basis, this commit suggests that people use
Pull Panda instead, which offers a superset of the functionality
for free (since GitHub acquired Pull Panda).